### PR TITLE
Check whether current CWD is a symlink when normalizing paths.

### DIFF
--- a/command/meta_config.go
+++ b/command/meta_config.go
@@ -42,6 +42,11 @@ func (m *Meta) normalizePath(path string) string {
 		return path
 	}
 
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return path
+	}
+
 	ret, err := filepath.Rel(cwd, path)
 	if err != nil {
 		return path

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/uuid v1.1.1
 	github.com/gophercloud/gophercloud v0.0.0-20190208042652-bc37892e1968


### PR DESCRIPTION
Corresponds to PR in upstream Terraform: https://github.com/hashicorp/terraform/pull/24197

If terraform init is run in a symlinked directory at a different level in the hierarchy than its symlinked target, terraform will fail to resolve the relative path generated based on the target. This commit checks whether the current working directory is a symlink and builds the relative path based on the result.

Helps to fix openshift/installer#1839 and https://bugzilla.redhat.com/show_bug.cgi?id=1767066

https://github.com/openshift/hashicorp-terraform/commit/731ca36f5e668a9bb66bb419e9d3046f779ebc5b was automatically generated.

cc @abhinavdahiya 

I will need to look into bumping openshift installer 