### PR TITLE
UPSTREAM: #24197 Check if CWD is a symlink when normalizing paths

### DIFF
--- a/command/meta_config.go
+++ b/command/meta_config.go
@@ -42,6 +42,11 @@ func (m *Meta) normalizePath(path string) string {
 		return path
 	}
 
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return path
+	}
+
 	ret, err := filepath.Rel(cwd, path)
 	if err != nil {
 		return path


### PR DESCRIPTION
If terraform init is run in a symlinked directory at a different level in the hierarchy than its symlinked target, terraform will fail to resolve the relative path generated based on the target. This commit checks whether the current working directory is a symlink and builds the relative path based on the result.