### PR TITLE
CARRY: backend: drop un-used remote backeds in terraform

### DIFF
--- a/backend/init/init.go
+++ b/backend/init/init.go
@@ -10,22 +10,7 @@ import (
 	"github.com/hashicorp/terraform/backend"
 	"github.com/zclconf/go-cty/cty"
 
-	backendAtlas "github.com/hashicorp/terraform/backend/atlas"
 	backendLocal "github.com/hashicorp/terraform/backend/local"
-	backendRemote "github.com/hashicorp/terraform/backend/remote"
-	backendArtifactory "github.com/hashicorp/terraform/backend/remote-state/artifactory"
-	backendAzure "github.com/hashicorp/terraform/backend/remote-state/azure"
-	backendConsul "github.com/hashicorp/terraform/backend/remote-state/consul"
-	backendEtcdv2 "github.com/hashicorp/terraform/backend/remote-state/etcdv2"
-	backendEtcdv3 "github.com/hashicorp/terraform/backend/remote-state/etcdv3"
-	backendGCS "github.com/hashicorp/terraform/backend/remote-state/gcs"
-	backendHTTP "github.com/hashicorp/terraform/backend/remote-state/http"
-	backendInmem "github.com/hashicorp/terraform/backend/remote-state/inmem"
-	backendManta "github.com/hashicorp/terraform/backend/remote-state/manta"
-	backendOSS "github.com/hashicorp/terraform/backend/remote-state/oss"
-	backendPg "github.com/hashicorp/terraform/backend/remote-state/pg"
-	backendS3 "github.com/hashicorp/terraform/backend/remote-state/s3"
-	backendSwift "github.com/hashicorp/terraform/backend/remote-state/swift"
 )
 
 // backends is the list of available backends. This is a global variable
@@ -49,32 +34,7 @@ func Init(services *disco.Disco) {
 
 	backends = map[string]backend.InitFn{
 		// Enhanced backends.
-		"local":  func() backend.Backend { return backendLocal.New() },
-		"remote": func() backend.Backend { return backendRemote.New(services) },
-
-		// Remote State backends.
-		"artifactory": func() backend.Backend { return backendArtifactory.New() },
-		"atlas":       func() backend.Backend { return backendAtlas.New() },
-		"azurerm":     func() backend.Backend { return backendAzure.New() },
-		"consul":      func() backend.Backend { return backendConsul.New() },
-		"etcd":        func() backend.Backend { return backendEtcdv2.New() },
-		"etcdv3":      func() backend.Backend { return backendEtcdv3.New() },
-		"gcs":         func() backend.Backend { return backendGCS.New() },
-		"http":        func() backend.Backend { return backendHTTP.New() },
-		"inmem":       func() backend.Backend { return backendInmem.New() },
-		"manta":       func() backend.Backend { return backendManta.New() },
-		"oss":         func() backend.Backend { return backendOSS.New() },
-		"pg":          func() backend.Backend { return backendPg.New() },
-		"s3":          func() backend.Backend { return backendS3.New() },
-		"swift":       func() backend.Backend { return backendSwift.New() },
-
-		// Deprecated backends.
-		"azure": func() backend.Backend {
-			return deprecateBackend(
-				backendAzure.New(),
-				`Warning: "azure" name is deprecated, please use "azurerm"`,
-			)
-		},
+		"local": func() backend.Backend { return backendLocal.New() },
 	}
 }
 


### PR DESCRIPTION
Currently these backends force the installer to vendor in these libraries
forcing the installer to deal with old cloud libraries.

The installer does not use these remote backends anyway, so this should help
a lot to reduce the un-used codepaths and allow installer to use cloud libraries tied to
the providers instead.